### PR TITLE
init: Don't crash the system due to an invalid mkdir argument

### DIFF
--- a/init/builtins.cpp
+++ b/init/builtins.cpp
@@ -303,7 +303,12 @@ static int do_mkdir(const std::vector<std::string>& args) {
     /* mkdir <path> [mode] [owner] [group] */
 
     if (args.size() >= 3) {
-        mode = std::stoul(args[2], 0, 8);
+        unsigned long mode_ul;
+        if (sscanf(args[2].c_str(), "%lo", &mode_ul) != 1) {
+            ERROR("mkdir: invalid mode %s\n", args[2].c_str());
+            return -EINVAL;
+        }
+        mode = (mode_t) mode_ul;
     }
 
     ret = make_dir(args[1].c_str(), mode);


### PR DESCRIPTION
Prior to this change, if someone write

```
  mkdir /data/log/sar_cap system system
```

in one of their init.rc files, this causes init to get a exception
which causes init to exit with no error message to allow you to track
this down which then causes your kernel to panic.

Let's make this a little more user friendly by simply reporting
an error instead of silently crashing the whole damn system.

Change-Id: I2f8c50391e78a9992d33754cf1f1e34e9fcee047
